### PR TITLE
Some minor tweaks around env activation

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,8 @@ func main() {
 		err = g.Exec("go", os.Args[2:]...)
 	case "env":
 		g.PrintEnv()
+	case "deactivate":
+		g.PrintEnvDeactivate()
 	default:
 		err = errors.New(`unrecognized command "` + cmd + `"`)
 	}
@@ -80,7 +82,8 @@ The commands are:
 
     install     install the dependencies specified by Goopfile or Goopfile.lock
     update      update dependencies to their latest versions
-    env         print GOPATH and PATH environment variables, with the vendor path prepended
+    env         print shell commands to activate vendor environment
+    deactivate  print shell commands to deactivate vendor environment
     exec        execute a command in the context of the installed dependencies
     go          execute a go command in the context of the installed dependencies
     help        print this message


### PR DESCRIPTION
This fixes #4 (set GOBIN) and #8 (replace GOPATH), and adds a "deactivate" command similar to the same command in virtualenv.

You may or may not be interested in these changes, but I thought I'd throw them out there. A couple of thoughts:
- `deactivate` is definitely useful, but only works for Bourne shell variants (sh, bash, zsh). Won't work for csh, fish, etc. It would be a bit more work to make it work across shells.
- I'm not sure what your opinion on #4 and #8 are, so you might not want those changes. I can back them out.

eg.

Activate an environment:

```
~/Projects/3rdParty/goop$ goop env
_OLD_GOPATH="$GOPATH"
_OLD_GOBIN="$GOBIN"
_OLD_PATH="$PATH"
GOPATH=/Users/alec/Projects/3rdParty/goop/.vendor
GOBIN=/Users/alec/Projects/3rdParty/goop/.vendor/bin
PATH=/Users/alec/Projects/3rdParty/goop/.vendor/bin:/usr/local/bin:/usr/local/go/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/alec/.cabal/bin
```

Deactivate an environment:

```
~/Projects/3rdParty/goop$ goop deactivate
GOPATH="$_OLD_GOPATH"
unset _OLD_GOPATH
GOBIN="$_OLD_GOBIN"
unset _OLD_GOBIN
PATH="$_OLD_PATH"
unset _OLD_PATH
```
