### PR TITLE
Add default GOPATH definition for later version of golang

### DIFF
--- a/goop/goop.go
+++ b/goop/goop.go
@@ -34,6 +34,12 @@ func NewGoop(dir string, stdin io.Reader, stdout io.Writer, stderr io.Writer) *G
 }
 
 func (g *Goop) patchedEnv(replace bool) []string {
+	// Later versions of go require GOPATH to be defined; if it's not defined,
+	// default it to the vendor dir
+	if os.Getenv("GOPATH") == "" {
+		os.Setenv("GOPATH", g.vendorDir())
+	}
+
 	sysEnv := os.Environ()
 	env := make([]string, len(sysEnv))
 	copy(env, sysEnv)


### PR DESCRIPTION
Later versions of golang require a GOPATH defined in the environment; this patch ensures it's available, defaulted as the vendor directory.
