### PR TITLE
Add support for bzr

### DIFF
--- a/goop/goop.go
+++ b/goop/goop.go
@@ -327,6 +327,16 @@ func (g *Goop) currentRev(vcsCmd string, path string) (string, error) {
 		} else {
 			return strings.TrimSpace(string(rev)), err
 		}
+	case "bzr":
+		cmd := exec.Command("bzr", "revno")
+		cmd.Dir = path
+		cmd.Stderr = g.stderr
+		rev, err := cmd.Output()
+		if err != nil {
+			return "", err
+		} else {
+			return strings.TrimSpace(string(rev)), err
+		}
 	}
 	return "", &UnsupportedVCSError{VCS: vcsCmd}
 }
@@ -355,7 +365,13 @@ func (g *Goop) checkout(vcsCmd string, path string, tag string) error {
 		if err != nil {
 			return err
 		}
-		return g.quietCommand(path, "hg", "update", tag).Run()
+		return g.quietCommand(path, "hg", "update", tag)
+	case "bzr":
+		err := g.execInPath(path, "bzr", "update")
+		if err != nil {
+			return err
+		}
+		return g.quietCommand(path, "bzr", "update", "-r", tag)
 	}
 	return &UnsupportedVCSError{VCS: vcsCmd}
 }


### PR DESCRIPTION
Add support for bzr repositories.

I've tested this on the "mgo" repository (labix.org/v2/mgo). My Goopfile is has `labix.org/v2/mgo #r2014.03.12`. It should check out revision `r271` after it checks out the tag.
