### PR TITLE
Add "goop install package" support

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,11 +26,42 @@ func main() {
 	}
 
 	cmd := os.Args[1]
+	pkg, savedev := "", false
+
 	switch cmd {
 	case "help":
 		printUsage()
 	case "install":
-		err = g.Install()
+		if len(os.Args) > 2 {
+			pkg = os.Args[2] //install the specified package
+			argLen := len(os.Args)
+
+			dev := os.Args[argLen-1]
+			if "--save-dev" != dev {
+				if pkg == "--save-dev" {
+					savedev = true
+					pkgs := os.Args[3:]
+
+					pkg = strings.Join(pkgs, " ")
+				} else {
+					savedev = false //unset the save dev config
+					pkgs := os.Args[2:]
+
+					pkg = strings.Join(pkgs, " ")
+				}
+
+			} else {
+				savedev = true
+				pkgs := os.Args[2 : argLen-1]
+
+				pkg = strings.Join(pkgs, " ")
+			}
+
+			err = g.InstallPkg(pkg, savedev)
+		} else {
+			err = g.Install()
+		}
+
 	case "update":
 		err = g.Update()
 	case "exec":


### PR DESCRIPTION
## Features from this pull request

By leverage the `npm` command, I added the package installation support to `goop install`, then you can use:
- `goop install` to continue installing all packages from the local `Goopfile` file
- `goop install github.com/revel/revel` to install one package you specified from the command line
- `goop install github.com/revel/revel #tag` to install the package with the specified tag name

And also, there is one new arg supported to the `install` command, which is `--save-dev` which is the same as `npm`,
- `goop install github.com/revel/revel --save-dev`, the `goop` command will install the package `github.com/revel/revel` and it will also append the package `github.com/revel/revel` to the `Goopfile` file for convenient, or
- `goop install --save-dev github.com/revel/revel` which is the same as `goop install github.com/revel/revel --save-dev`
## Changes are made

Added the `install arg` support to the main.go file;

Added one new method `InstallPkg` to goop/goop.go file, logic:
- Create one tmp file ".Goopfile" and copy all the packages from "Goopfile" if it exists to ".Goopfile"
- Append the new package to the end of this file
- Call `g.parseAndInstall(gftmp, true)` to reuse the original logic to install the new packages in the file ".Goopfile"
- If `--save-dev` is true, then mv the tmp file ".Goopfile" to "Goopfile"
