### PR TITLE
Detect VCS based on an URL.

### DIFF
--- a/goop/vcs.go
+++ b/goop/vcs.go
@@ -1,6 +1,7 @@
 package goop
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -17,7 +18,11 @@ func GuessVCS(url string) string {
 		return "git"
 	case strings.HasPrefix(url, "git@"):
 		return "git"
+	case strings.HasSuffix(url, ".git"):
+		return "git"
 	case strings.HasPrefix(url, "ssh://hg@"):
+		return "hg"
+	case strings.HasSuffix(url, ".hg"):
 		return "hg"
 	default:
 		return ""
@@ -54,5 +59,14 @@ func RepoRootForImportPathWithURLOverride(importPath string, url string) (*vcs.R
 		return nil, err
 	}
 	repo.Repo = url
+
+	vcs_guess := GuessVCS(url)
+	if vcs_guess != "" {
+		repo.VCS = vcs.ByCmd(vcs_guess)
+		if repo.VCS == nil {
+			return nil, fmt.Errorf("Unrecognized VCS %s in %s ", vcs_guess, url)
+		}
+	}
+
 	return repo, nil
 }

--- a/goop/vcs_test.go
+++ b/goop/vcs_test.go
@@ -24,7 +24,7 @@ var _ = Describe("vcs", func() {
 		{"bitbucket.org/kardianos/osext", "ssh://hg@bitbucket.org/kardianos/osext", "hg", "hg", "bitbucket.org/kardianos/osext"},
 		{"bitbucket.org/kardianos/osext", "https://bitbucket.org/kardianos/osext", "", "hg", "bitbucket.org/kardianos/osext"},
 		{"bitbucket.org/ymotongpoo/go-bitarray", "git@bitbucket.org:ymotongpoo/go-bitarray.git", "git", "git", "bitbucket.org/ymotongpoo/go-bitarray"},
-		{"bitbucket.org/ymotongpoo/go-bitarray", "https://bitbucket.org/ymotongpoo/go-bitarray.git", "", "git", "bitbucket.org/ymotongpoo/go-bitarray"},
+		{"bitbucket.org/ymotongpoo/go-bitarray", "https://bitbucket.org/ymotongpoo/go-bitarray.git", "git", "git", "bitbucket.org/ymotongpoo/go-bitarray"},
 		{"code.google.com/p/go.tools/go/vcs", "https://code.google.com/p/go.tools/", "", "hg", "code.google.com/p/go.tools"},
 		// not supported yet - {"example.com/foo/go-sqlite3", "git@github.com:mattn/go-sqlite3.git", "git", "git", "example.com/foo/go-sqlite3"},
 	}


### PR DESCRIPTION
Used when fetching dependencies from custom URLs.

Previously only package name was used for this, e.g. packages with names
code.google.com/... are always fetched using Mercurial (if original repository
on code.google.com is Mercurial), even though custom URL may point to a Git
mirror.

---

Note that I decided not to use IdentifyVCS for this, since I dislike the idea of sending git or hg requests into the unknown. If GuessVCS fails to detect repository flavor, a default decision made by vcs.RepoRootForImportPathStatic is used as before.

(Also I find it curious that IdentifyVCS is defined and has a test, but not actually used).
