### PR TITLE
Adding support for Windows.

### DIFF
--- a/goop/goop.go
+++ b/goop/goop.go
@@ -56,9 +56,9 @@ func (g *Goop) PrintEnv() {
 	if gopath == "" {
 		g.stdout.Write([]byte(fmt.Sprintf("GOPATH=%s\n", g.vendorDir())))
 	} else {
-		g.stdout.Write([]byte(fmt.Sprintf("GOPATH=%s:%s\n", g.vendorDir(), gopath)))
+		g.stdout.Write([]byte(fmt.Sprintf("GOPATH=%s%s%s\n", g.vendorDir(), env.PathListSeparator, gopath)))
 	}
-	g.stdout.Write([]byte(fmt.Sprintf("PATH=%s:%s\n", path.Join(g.vendorDir(), "bin"), os.Getenv("PATH"))))
+	g.stdout.Write([]byte(fmt.Sprintf("PATH=%s%s%s\n", path.Join(g.vendorDir(), "bin"), env.PathListSeparator, os.Getenv("PATH"))))
 }
 
 func (g *Goop) Exec(name string, args ...string) error {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -3,7 +3,10 @@ package env
 import (
 	"bytes"
 	"os"
+	"runtime"
 )
+
+var PathListSeparator = ":"
 
 type Env map[string]string
 
@@ -38,5 +41,11 @@ func (e Env) Prepend(key string, val string) {
 		e[key] = val
 		return
 	}
-	e[key] = val + ":" + oldv
+	e[key] = val + PathListSeparator + oldv
+}
+
+func init() {
+	if runtime.GOOS == "windows" {
+		PathListSeparator = ";"
+	}
 }

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -52,9 +52,9 @@ var _ = Describe("env", func() {
 		Context("when a given key has a value", func() {
 			It("prepends new value to the existing value", func() {
 				e.Prepend("_GOOP_ENV_TEST_FOO", "lol")
-				Expect(e["_GOOP_ENV_TEST_FOO"]).To(Equal("lol:foo"))
+				Expect(e["_GOOP_ENV_TEST_FOO"]).To(Equal("lol" + env.PathListSeparator + "foo"))
 				e.Prepend("_GOOP_ENV_TEST_FOO", "hello")
-				Expect(e["_GOOP_ENV_TEST_FOO"]).To(Equal("hello:lol:foo"))
+				Expect(e["_GOOP_ENV_TEST_FOO"]).To(Equal("hello" + env.PathListSeparator + "lol" + env.PathListSeparator + "foo"))
 			})
 		})
 
@@ -63,7 +63,7 @@ var _ = Describe("env", func() {
 				e.Prepend("_GOOP_ENV_TEST_EMPTY", "foo")
 				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("foo"))
 				e.Prepend("_GOOP_ENV_TEST_EMPTY", "lol")
-				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("lol:foo"))
+				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("lol" + env.PathListSeparator + "foo"))
 			})
 		})
 
@@ -76,7 +76,7 @@ var _ = Describe("env", func() {
 				e.Prepend("_GOOP_ENV_TEST_EMPTY", "foo")
 				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("foo"))
 				e.Prepend("_GOOP_ENV_TEST_EMPTY", "lol")
-				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("lol:foo"))
+				Expect(e["_GOOP_ENV_TEST_EMPTY"]).To(Equal("lol" + env.PathListSeparator + "foo"))
 			})
 		})
 	})


### PR DESCRIPTION
Currently, running goop on Windows fails because the path is not being modified correctly.
Windows uses `;` not `:` to concatenate paths in a list.
