### PR TITLE
Add ``install --path`` argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.goop
 .vendor
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)

--- a/Goopfile
+++ b/Goopfile
@@ -1,3 +1,4 @@
 github.com/onsi/ginkgo/ginkgo
 github.com/onsi/gomega
 code.google.com/p/go.tools/go/vcs
+github.com/alecthomas/kingpin

--- a/Goopfile.lock
+++ b/Goopfile.lock
@@ -1,3 +1,7 @@
+code.google.com/p/go.net #937a34c9de13c766c814510f76bca091dee06028
+code.google.com/p/go.tools/go/vcs #c5e1d3cb5e8e8c1c7c0738642555d7669d1d41e0
+github.com/alecthomas/kingpin #55a69a226d28a43b913720f5d765706d49c8fa9e
+github.com/alecthomas/units #6b4e7dc5e3143b85ea77909c72caf89416fc2915
 github.com/onsi/ginkgo/ginkgo #12446bbcc74950944c897e32ea99cc8d058f9c92
 github.com/onsi/gomega #036273e6f643552b16fe7a6464afd2ae0324992e
-code.google.com/p/go.tools/go/vcs #c5e1d3cb5e8e8c1c7c0738642555d7669d1d41e0
+golang.org/x/net #b6fdb7d8a4ccefede406f8fe0f017fb58265054c

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ A dependency manager for Go (golang), inspired by Bundler. It is different from 
    github.com/gorilla/mux !git@github.com:nitrous-io/mux.git // override repo url
    ```
 
-3. Run `goop install`. This will install packages inside a subdirectory called `.vendor` and create `Goopfile.lock`, recording exact versions used for each package and its dependencies. Subsequent `goop install` runs will ignore `Goopfile` and install the versions specified in `Goopfile.lock`. You should check this file in to your source version control. It's a good idea to add `.vendor` to your version control system's ignore settings (e.g. `.gitignore`).
+3. Run `goop install`. This will install packages inside a subdirectory called `.vendor` and create `Goopfile.lock`, 
+   recording exact versions used for each package and its dependencies. Subsequent `goop install` runs will ignore `Goopfile` 
+   and install the versions specified in `Goopfile.lock`. You should check this file in to your source version control. 
+   It's a good idea to add `.vendor` to your version control system's ignore settings (e.g. `.gitignore`).
+   Use ``goop install --path my/deps`` to install to another directory.
 
 4. Run commands using `goop exec` (e.g. `goop exec make`). This will execute your command in an environment that has correct `GOPATH` and `PATH` set.
 

--- a/main.go
+++ b/main.go
@@ -1,14 +1,29 @@
 package main
 
 import (
-	"errors"
+	"github.com/alecthomas/kingpin"
+	"github.com/mattes/goop/goop"
+	"github.com/nitrous-io/goop/colors"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+)
 
-	"github.com/nitrous-io/goop/colors"
-	"github.com/nitrous-io/goop/goop"
+var (
+	app = kingpin.New("goop", "A a tool for managing Go dependencies.")
+
+	installCmd  = app.Command("install", "Install the dependencies specified by Goopfile or Goopfile.lock")
+	installPath = installCmd.Flag("path", "Install dependencies to this directory").String()
+
+	updateCmd = app.Command("update", "Update dependencies to their latest versions")
+	envCmd    = app.Command("env", "Print GOPATH and PATH environment variables, with the vendor path prepended")
+
+	execCmd  = app.Command("exec", "Execute a command in the context of the installed dependencies")
+	execArgs = StringList(execCmd.Arg("command", "Command and arguments to execute").Required())
+
+	goCmd  = app.Command("go", "Execute a go command in the context of the installed dependencies")
+	goArgs = StringList(goCmd.Arg("command", "Command and arguments to execute").Required())
 )
 
 func main() {
@@ -19,34 +34,38 @@ func main() {
 		os.Stderr.WriteString(colors.Error + name + ": failed to determine present working directory!" + colors.Reset + "\n")
 	}
 
-	g := goop.NewGoop(path.Join(pwd), os.Stdin, os.Stdout, os.Stderr)
-
-	if len(os.Args) < 2 {
-		printUsage()
+	g, err := goop.NewGoop(path.Join(pwd), os.Stdin, os.Stdout, os.Stderr)
+	if err != nil {
+		os.Stderr.WriteString(colors.Error + name + ": " + err.Error() + colors.Reset + "\n")
+		os.Exit(1)
 	}
 
-	cmd := os.Args[1]
-	switch cmd {
-	case "help":
-		printUsage()
-	case "install":
-		err = g.Install()
-	case "update":
+	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
+
+	case installCmd.FullCommand():
+		err = g.Install(*installPath)
+
+	case updateCmd.FullCommand():
 		err = g.Update()
-	case "exec":
-		if len(os.Args) < 3 {
-			printUsage()
-		}
-		err = g.Exec(os.Args[2], os.Args[3:]...)
-	case "go":
-		if len(os.Args) < 3 {
-			printUsage()
-		}
-		err = g.Exec("go", os.Args[2:]...)
-	case "env":
+
+	case envCmd.FullCommand():
 		g.PrintEnv()
+
+	case execCmd.FullCommand():
+		args := *execArgs
+		if len(args) > 0 {
+			err = g.Exec(args[0], args[1:]...)
+		}
+
+	case goCmd.FullCommand():
+		args := *goArgs
+		if len(args) > 0 {
+			err = g.Exec("go", args...)
+		}
+
 	default:
-		err = errors.New(`unrecognized command "` + cmd + `"`)
+		app.Usage(os.Stdout)
+
 	}
 
 	if err != nil {
@@ -68,22 +87,23 @@ func main() {
 	}
 }
 
-func printUsage() {
-	os.Stdout.WriteString(strings.TrimSpace(usage) + "\n\n")
-	os.Exit(0)
+type stringList []string
+
+func (l *stringList) Set(value string) error {
+	*l = append(*l, value)
+	return nil
 }
 
-const usage = `
-Goop is a tool for managing Go dependencies.
+func (l *stringList) String() string {
+	return ""
+}
 
-        goop command [arguments]
+func (l *stringList) IsCumulative() bool {
+	return true
+}
 
-The commands are:
-
-    install     install the dependencies specified by Goopfile or Goopfile.lock
-    update      update dependencies to their latest versions
-    env         print GOPATH and PATH environment variables, with the vendor path prepended
-    exec        execute a command in the context of the installed dependencies
-    go          execute a go command in the context of the installed dependencies
-    help        print this message
-`
+func StringList(s kingpin.Settings) (target *[]string) {
+	target = new([]string)
+	s.SetValue((*stringList)(target))
+	return
+}

--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/alecthomas/kingpin"
-	"github.com/mattes/goop/goop"
 	"github.com/nitrous-io/goop/colors"
+	"github.com/nitrous-io/goop/goop"
 	"os"
 	"path"
 	"strconv"


### PR DESCRIPTION
Allow to install to different directories than `.vendor`. This will create a config file `.goop/config` to store the install path.
