### PR TITLE
Specify the vendor path for goop to use.

### DIFF
--- a/goop/goop.go
+++ b/goop/goop.go
@@ -302,7 +302,13 @@ func (g *Goop) parseAndInstall(goopfile *os.File, writeLockFile bool) error {
 }
 
 func (g *Goop) vendorDir() string {
-	return path.Join(g.dir, ".vendor")
+	vendorDir := os.Getenv("GOOP_VENDOR_DIR")
+
+	if vendorDir == "" {
+		vendorDir = path.Join(g.dir, ".vendor")
+	}
+
+	return vendorDir
 }
 
 func (g *Goop) currentRev(vcsCmd string, path string) (string, error) {

--- a/goop/goop_test.go
+++ b/goop/goop_test.go
@@ -1,11 +1,30 @@
-package goop_test
+package goop
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("Goop", func() {
+	Describe("vendorDir()", func() {
+
+		It("Utilizes 'GOOP_VENDOR_DIR' environ variable when defined", func() {
+			os.Setenv("GOOP_VENDOR_DIR", "fake-goop-vendor-dir")
+			dir := NewGoop("./", os.Stdin, os.Stdout, os.Stderr).vendorDir()
+			Expect("fake-goop-vendor-dir").To(Equal(dir))
+		})
+
+		It("Defaults to '.vendors' in the base directory", func() {
+			os.Unsetenv("GOOP_VENDOR_DIR")
+			dir := NewGoop("/", os.Stdin, os.Stdout, os.Stderr).vendorDir()
+			Expect("/.vendor").To(Equal(dir))
+		})
+
+	})
+})
 
 func Test(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
It is useful to be able to specify the vendor path to use. This makes things easier when setting up custom go environments.
